### PR TITLE
Reverse versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ bxpatch <in file> <out file> <bxdiff patch file>
 3. libcrypto
 
 # build
-- make # build for iOS
-- make -f Makefile.osx # build for OS X
+- make # build for OS X
+- make -f Makefile.ios # build for iOS


### PR DESCRIPTION
The makefile instructions were reversed. Merging this PR will reverse them back to what they should be (Makefile -> OS X, Makefile.ios  -> iOS).
